### PR TITLE
fixes a bug that caused a loop when awarding cards

### DIFF
--- a/scripts/config/create-context.js
+++ b/scripts/config/create-context.js
@@ -118,7 +118,7 @@ export const makeMenuItems = () => {
 							label: 'Recall Cards',
 							callback: async () => {
 								await MMI.recallCards()
-								ui.notifications.info('Mildly Magical Inspiration: All cards were recalled back into the deck successfully!');
+								ui.notifications.info('<b>Mildly Magical Inspiration:</b> All cards were recalled back into the deck successfully!');
 							}
 						}
 					}

--- a/scripts/config/register-sockets.js
+++ b/scripts/config/register-sockets.js
@@ -13,7 +13,7 @@ export default function () {
 				if(data.userId === game.user._id) multipleChoice(data.offer);
 				break;
 			case 'setSetting':
-				MMI.pushGamemasterSetting(data.setting, data.data, data.hookEmitter);
+				if(game.user.role === 4) MMI.pushGamemasterSetting(data.setting, data.data, data.hookEmitter);
 				break;
 			case 'sendNotification':
 				if(game.user._id === data.recipient) ui.notifications.info(data.message);

--- a/scripts/modules/hook-emitter.js
+++ b/scripts/modules/hook-emitter.js
@@ -1,10 +1,6 @@
 import MMI, { SourceFactory } from '/modules/mmi/scripts/main.js';
 import DEFAULTS from '/modules/mmi/scripts/defaults.js';
 
-import CardViewerApplication from '/modules/mmi/scripts/apps/CardViewerApplication.js';
-import DeckConfigApplication from '/modules/mmi/scripts/apps/DeckConfigApplication.js';
-import SourceConfigApplication from '/modules/mmi/scripts/apps/SourceConfigApplication.js';
-
 const _sendNotification = (msg, includeSelf = false) => {
     if(includeSelf) ui.notifications.info(msg)
     game.users.forEach(user => {
@@ -151,6 +147,31 @@ export default {
             }
 
             await SourceFactory.update(MMI.activeSource._id, { cards: newCards })
+        }
+    },
+
+    recall(hookEmitter) {
+        _checkWindows(id => {
+            switch (apps[id].constructor.name) {
+                case 'CardViewerApplication':
+                    apps[id].close();
+                    break;
+                
+                case 'DeckConfigApplication':
+                    apps[id].render(true);
+                    break;
+            }
+        })
+
+        if(game.user.role != 4) {
+            ui.notifications.info('<b>Mildly Magical Inspiration:</b> All cards were recalled back into the deck by the gamemaster!');
+        }
+
+        if(game.user.role === 4) {
+            game.users.forEach(user => {
+                MMI.clearQueue('multipleChoice', user._id);
+            });
+            MMI.socket('triggerHook', hookEmitter);
         }
     }
 }


### PR DESCRIPTION
As noted by [issue#19](https://github.com/EvaTheDM/mildly-magical-inspiration/issues/19) a loop begins running when awarding cards, while more than two users (one of them the gamemaster) are online.

The bug was caused due to a hook being called by everyone to update settings without first checking if they were a gamemaster capable of updating the settings.

Additionally recalling the cards to the deck now causes all open Card Viewer windows (viewing one's hand, award window, etc.) to close and the Deck Config window to rerender, as well as removing all cards from players' queues.